### PR TITLE
General refactors and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,16 @@
 version = 3
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "lc3-vm"
 version = "0.1.0"
 dependencies = [
+ "byteorder",
  "termios",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,34 +3,9 @@
 version = 3
 
 [[package]]
-name = "autocfg"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "cc"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "lc3-vm"
 version = "0.1.0"
 dependencies = [
- "nix",
  "termios",
 ]
 
@@ -39,28 +14,6 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "memoffset",
-]
 
 [[package]]
 name = "termios"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+byteorder = "1.5.0"
 termios = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nix = "0.23"
 termios = "0.3"

--- a/README.md
+++ b/README.md
@@ -11,15 +11,20 @@ This project is an implementation of a simple LC-3 (Little Computer 3) virtual m
 
 1. Clone the repository.
 
-2. Run the VM.
-    
-    You can run the VM with one or more LC-3 object files as arguments. Replace `object-file1` and `object-file2` with the paths to your LC-3 object files.
-
+2. Install the VM.
     ```bash
-    cargo run object-file1 object-file2 ...
+    cargo install --path .
     ```
+
+3. Run the VM.
+
+    You can run the VM with one or more LC-3 object files as arguments. 
+    ```bash
+    lc3-vm object-file1 object-file2 ...
+    ```
+    Replace `object-file1` and `object-file2` with the **paths** to your LC-3 object files.
 
     Example:
     ```bash
-    cargo run assembly/rogue.obj
+    lc3-vm assembly/rogue.obj
     ```

--- a/src/hardware/memory.rs
+++ b/src/hardware/memory.rs
@@ -13,10 +13,15 @@ pub enum MemoryMappedRegister {
 }
 
 /// Struct representing the memory of the LC-3 VM.
-#[derive(Default)]
 pub struct Memory {
-    /// Vector storing the memory contents.
-    memory: Vec<u16>,
+    /// Array storing the memory contents.
+    memory: [u16; MEMORY_SIZE],
+}
+
+impl Default for Memory {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Memory {
@@ -27,7 +32,7 @@ impl Memory {
     /// A new instance of `Memory`.
     pub fn new() -> Self {
         Self {
-            memory: vec![0; MEMORY_SIZE],
+            memory: [0; MEMORY_SIZE],
         }
     }
 

--- a/src/hardware/registers.rs
+++ b/src/hardware/registers.rs
@@ -44,8 +44,8 @@ impl From<u16> for Register {
 /// Structure representing the registers of the LC-3 VM.
 #[derive(Default)]
 pub struct Registers {
-    /// Vector storing the registers contents.
-    registers: Vec<u16>,
+    /// Array storing the registers contents.
+    registers: [u16; Register::COUNT as usize],
 }
 
 impl Registers {
@@ -58,7 +58,7 @@ impl Registers {
     ///
     /// A new instance of `Registers`.
     pub fn new() -> Self {
-        let mut registers = vec![0; Register::COUNT as usize];
+        let mut registers = [0; Register::COUNT as usize];
         registers[Register::PC as usize] = PC_START;
         registers[Register::COND as usize] = Flag::ZRO as u16;
 

--- a/src/isa/traps.rs
+++ b/src/isa/traps.rs
@@ -114,7 +114,7 @@ fn puts(registers: &Registers, memory: &mut Memory) -> Result<(), String> {
             break;
         }
         print!("{}", word as u8 as char);
-        address += 1;
+        address = address.wrapping_add(1);
     }
     io::stdout().flush().map_err(|e| e.to_string())
 }
@@ -163,7 +163,7 @@ fn putsp(registers: &Registers, memory: &mut Memory) -> Result<(), String> {
             print!("{}", char2);
         }
 
-        address += 1;
+        address = address.wrapping_add(1);
     }
     io::stdout().flush().map_err(|e| e.to_string())
 }

--- a/src/isa/traps.rs
+++ b/src/isa/traps.rs
@@ -94,8 +94,8 @@ fn getc(registers: &mut Registers) -> Result<(), String> {
 /// # Parameters
 /// - `registers`: A reference to the `Registers` object.
 fn out(registers: &Registers) -> Result<(), String> {
-    let ch = registers.read(Register::R0);
-    print!("{}", ch as u8 as char);
+    let ch = char::from((registers.read(Register::R0) & 0xFF) as u8);
+    print!("{}", ch);
     io::stdout().flush().map_err(|e| e.to_string())
 }
 
@@ -113,7 +113,7 @@ fn puts(registers: &Registers, memory: &mut Memory) -> Result<(), String> {
         if word == 0 {
             break;
         }
-        print!("{}", word as u8 as char);
+        print!("{}", char::from((word & 0xFF) as u8));
         address = address.wrapping_add(1);
     }
     io::stdout().flush().map_err(|e| e.to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::process::exit;
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: cargo run [object-file1] ...");
+        eprintln!("Usage: lc3-vm [object-file1] ...");
         exit(2);
     }
     let mut vm = VM::new();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,9 @@
 use nix::sys::select::{select, FdSet};
 use nix::sys::time::{TimeVal, TimeValLike};
 use std::io::{self, Read};
-use std::os::unix::io::RawFd;
 use termios::{tcsetattr, Termios, ECHO, ICANON, TCSANOW};
 
-const STDIN_FD: RawFd = 0; // File descriptor for standard input
+const STDIN_FD: i32 = 0; // File descriptor for standard input
 
 /// Disables input buffering to allow immediate reading of input.
 ///

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,3 @@
-use nix::sys::select::{select, FdSet};
-use nix::sys::time::{TimeVal, TimeValLike};
 use std::io::{self, Read};
 use termios::{tcsetattr, Termios, ECHO, ICANON, TCSANOW};
 
@@ -22,21 +20,6 @@ pub fn disable_input_buffering() -> io::Result<Termios> {
 /// This function restores the terminal settings to their original state, as obtained from `disable_input_buffering`.
 pub fn restore_input_buffering(original_tio: &Termios) -> io::Result<()> {
     tcsetattr(STDIN_FD, TCSANOW, original_tio)
-}
-
-/// Checks if a key has been pressed on standard input.
-///
-/// This function uses the `select` system call to determine if there is any data available to read from standard input.
-/// Returns `true` if a key has been pressed, `false` otherwise.
-pub fn check_key() -> bool {
-    let mut read_fds = FdSet::new();
-    read_fds.insert(STDIN_FD);
-    let mut timeout = TimeVal::zero();
-
-    match select(None, Some(&mut read_fds), None, None, Some(&mut timeout)) {
-        Ok(n) => n > 0 && read_fds.contains(STDIN_FD),
-        Err(_) => false,
-    }
 }
 
 /// Reads a single character from standard input.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,8 +1,9 @@
-use crate::hardware::memory::{Memory, MEMORY_SIZE};
+use crate::hardware::memory::Memory;
 use crate::hardware::registers::*;
 use crate::isa::{instructions::*, traps};
+use byteorder::{BigEndian, ReadBytesExt};
 use std::fs::File;
-use std::io::Read;
+use std::io::BufReader;
 
 /// The VM struct represents the LC-3 virtual machine, containing the memory and registers.
 #[derive(Default)]
@@ -32,29 +33,18 @@ impl VM {
     ///
     /// # Errors
     ///
-    /// Returns a `String` error if the file cannot be opened or read.
+    /// Returns a `String` error if the file cannot be opened, read, or if there is a memory overflow.
     pub fn read_image_file(&mut self, path: &str) -> Result<(), String> {
-        let mut file = File::open(path).map_err(|e| e.to_string())?;
-        let mut origin_bytes = [0u8; 2];
-        file.read_exact(&mut origin_bytes)
-            .map_err(|e| e.to_string())?;
-        let origin = u16::from_be_bytes(origin_bytes);
+        let file = File::open(path).map_err(|e| e.to_string())?;
+        let mut reader = BufReader::new(file);
 
-        let max_read = MEMORY_SIZE - origin as usize;
-        let mut buffer = vec![0u16; max_read];
-        let mut byte_buffer = vec![0u8; max_read * 2];
-        let read = file.read(&mut byte_buffer).map_err(|e| e.to_string())?;
-        let read_u16_count = read / 2;
-
-        for i in 0..read_u16_count {
-            let byte1 = byte_buffer[i * 2];
-            let byte2 = byte_buffer[i * 2 + 1];
-            let value = u16::from_be_bytes([byte1, byte2]);
-            buffer[i] = value;
-        }
-
-        for (i, value) in buffer.iter().take(read_u16_count).enumerate() {
-            self.memory.write(origin + i as u16, *value);
+        // origin (first 2 bytes)
+        let mut address = reader.read_u16::<BigEndian>().map_err(|e| e.to_string())?;
+        while let Ok(instr) = reader.read_u16::<BigEndian>() {
+            self.memory.write(address, instr);
+            address = address
+                .checked_add(1)
+                .ok_or("Memory overflow, object file is too large")?;
         }
 
         Ok(())


### PR DESCRIPTION
The main changes of this PR include:

- Adding more instructions tests.
- Including VM's installation (in `README.md`) and updating usage.
- Refactoring memory reading from `stdin` and `read_image_file`.
- Turning 'memory' and 'registers' from `Vec`s to fixed arrays.